### PR TITLE
Fix losing some part of the logs

### DIFF
--- a/pkg/api/server/v1alpha2/logs.go
+++ b/pkg/api/server/v1alpha2/logs.go
@@ -72,7 +72,7 @@ func (s *Server) PutLog(stream pb.Results_PutLogServer) error {
 		logChunk, err := stream.Recv()
 		// If we reach the end of the stream, we receive an io.EOF error
 		if err != nil {
-			return s.handleReturn(stream, dbRecord, taskRunLog, bytesWritten, err)
+			return s.handleReturn(stream, nil, taskRunLog, bytesWritten, err)
 		}
 		// Ensure that we are receiving logs for the same record
 		if recordName == "" {


### PR DESCRIPTION
Create task, pipeline and pipelinerun with delays:

```
apiVersion: tekton.dev/v1beta1
kind: Task
metadata:
  name: hello
spec:
  steps:
    - name: hello
      image: ubuntu
      script: |
        #!/bin/bash
        echo "A"; sleep 3; echo "Hello World!"; sleep 5; echo "Test!!!"
---
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  name: hello-run
spec:
  pipelineRef:
    name: hello
---
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  name: hello-run
spec:
  pipelineRef:
    name: hello
```

All taskrun logs should be stored:

```
[prepare] 2022/08/30 08:56:51 Entrypoint initialization

[prepare] 2022/08/30 08:56:51 Entrypoint initialization

[place-scripts] 2022/08/30 08:56:52 Decoded script /tekton/scripts/script-0-zkxmm
[prepare] 
2022/08/30 08:56:51 Entrypoint initialization

[place-scripts] 2022/08/30 08:56:52 Decoded script /tekton/scripts/script-0-zkxmm
[prepare] 
2022/08/30 08:56:51 Entrypoint initialization


[place-scripts] 2022/08/30 08:56:52 Decoded script /tekton/scripts/script-0-zkxmm

[hello] A

[prepare] 2022/08/30 08:56:51 Entrypoint initialization

[place-scripts] 2022/08/30 08:56:52 Decoded script /tekton/scripts/script-0-zkxmm

[hello] A
[hello] Hello World!
[hello] Test!!!
````


